### PR TITLE
Support for filtering array items

### DIFF
--- a/JLio.Extensions.JSchema/FilterBySchema.cs
+++ b/JLio.Extensions.JSchema/FilterBySchema.cs
@@ -49,8 +49,11 @@ namespace JLio.Extensions.JSchema
 
             foreach (var pathToRemove in GetPathsToRemove(inputObjectPaths, pathsInSchema))
             {
-                var token = currentObject.SelectToken(pathToRemove);
-                if (token != null) RemoveItems(currentObject, pathToRemove, context);
+                var tokens = currentObject.SelectTokens(pathToRemove);
+                if (tokens?.Any() == true) 
+                {
+                    RemoveItems(currentObject, pathToRemove, context);
+                }
             }
 
             return new JLioFunctionResult(true, currentObject);


### PR DESCRIPTION
The JToken.SelectToken(string path) expects a unique path, but all array items have the same path, for example "policy[*].processId"

The JToken.SelectToken will throw an exception in case more than one token is found for a path. 

Therefore, the JToken.SelectTokens(string path) should be used. This returns an IEnumerable<JToken>?. If there are any tokens, all tokens for this path are removed. To stay in the example I gave above, when pathToRemove equals "policy[*].processId", the "processId" property for all policies will be removed now and no exception is thrown.